### PR TITLE
fix: implement custom template functionality

### DIFF
--- a/cmd/createTemplate.go
+++ b/cmd/createTemplate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
@@ -22,9 +23,26 @@ The supported variables are:
 If there are any other variables you would like to see, please open an issue or a pull request the GitHub repository: jasonuc/greentext.
 If you want your template to be included in the default templates, please open a pull request on the GitHub repository: jasonuc/greentext.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		f, err := os.Create("template.html")
+		templateFileName, _ := cmd.Flags().GetString("output")
+		if templateFileName == "" {
+			templateFileName = "template.html"
+		}
+
+		// Check if file already exists
+		if _, err := os.Stat(templateFileName); err == nil {
+			fmt.Printf("File %s already exists. Do you want to overwrite it? (y/n): ", templateFileName)
+			var response string
+			fmt.Scanln(&response)
+			if response != "y" && response != "Y" {
+				fmt.Println("Operation cancelled")
+				return
+			}
+		}
+
+		f, err := os.Create(templateFileName)
 		if err != nil {
 			fmt.Println("Error creating template file:", err)
+			return
 		}
 
 		defer f.Close()
@@ -40,11 +58,15 @@ If you want your template to be included in the default templates, please open a
 			return
 		}
 
-		fmt.Println("Template file created successfully at template.html")
+		absPath, _ := filepath.Abs(templateFileName)
+		fmt.Println("Template file created successfully at", absPath)
 		fmt.Println("You can now edit the template file to your liking. Enjoy :)")
+		fmt.Println("\nTo use this template with the greentext command, run:")
+		fmt.Printf("  greentext --tmpl %s [other options]\n", templateFileName)
 	},
 }
 
 func init() {
+	createTemplateCmd.Flags().StringP("output", "o", "template.html", "Name of the template file to create")
 	rootCmd.AddCommand(createTemplateCmd)
 }

--- a/cmd/createTemplate.go
+++ b/cmd/createTemplate.go
@@ -32,7 +32,10 @@ If you want your template to be included in the default templates, please open a
 		if _, err := os.Stat(templateFileName); err == nil {
 			fmt.Printf("File %s already exists. Do you want to overwrite it? (y/n): ", templateFileName)
 			var response string
-			fmt.Scanln(&response)
+			if _, err := fmt.Scanln(&response); err != nil {
+				fmt.Println("Error reading input:", err)
+				return
+			}
 			if response != "y" && response != "Y" {
 				fmt.Println("Operation cancelled")
 				return

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	_ "embed"
 
@@ -36,6 +37,12 @@ Visit https://github.com/jasonuc/greentext for more information.`,
 		defaultTemplate, ok := cmd.Context().Value(defaultTemplateKey).([]byte)
 		if !ok {
 			fmt.Println("Invalid template passed")
+			return
+		}
+
+		customTemplatePath, err := getStringFlag("tmpl")
+		if err != nil {
+			fmt.Println("Error reading template flag:", err)
 			return
 		}
 
@@ -130,7 +137,21 @@ Visit https://github.com/jasonuc/greentext for more information.`,
 			return
 		}
 
-		err = gt.WriteToGreentext(dest, defaultTemplate, lines, thumbnail, font, fontSize, previewOnly, bgColor, textColor, width, height)
+		// Determine which template to use
+		var templateToUse []byte
+		if customTemplatePath != "" {
+			customTemplate, err := os.ReadFile(customTemplatePath)
+			if err != nil {
+				fmt.Println("Error reading custom template:", err)
+				return
+			}
+			templateToUse = customTemplate
+			fmt.Println("Using custom template from:", customTemplatePath)
+		} else {
+			templateToUse = defaultTemplate
+		}
+
+		err = gt.WriteToGreentext(dest, templateToUse, lines, thumbnail, font, fontSize, previewOnly, bgColor, textColor, width, height)
 		if err != nil {
 			fmt.Println("Error generating greentext:", err)
 			return


### PR DESCRIPTION
Implement the missing functionality for the --tmpl flag to allow using custom templates.

Changes:
- Read template files when `--tmpl` flag is used
- Use custom template instead of default when specified
- Add detail to `create-template` command