### PR TITLE
feat: add custom datetime with shorthand flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -157,7 +157,7 @@ Visit https://github.com/jasonuc/greentext for more information.`,
 			templateToUse = defaultTemplate
 		}
 
-		err = gt.WriteToGreentext(dest, templateToUse, lines, thumbnail, font, fontSize, previewOnly, bgColor, textColor, width, height)
+		err = gt.WriteToGreentext(dest, templateToUse, lines, thumbnail, font, fontSize, previewOnly, bgColor, textColor, width, height, customDateTime)
 		if err != nil {
 			fmt.Println("Error generating greentext:", err)
 			return

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,7 +130,13 @@ Visit https://github.com/jasonuc/greentext for more information.`,
 			return
 		}
 
-		err = gt.WriteToGreentext(dest, defaultTemplate, lines, thumbnail, font, fontSize, previewOnly, bgColor, textColor, width, height)
+		customDateTime, err := getStringFlag("datetime")
+		if err != nil {
+			fmt.Println("Error reading datetime flag:", err)
+			return
+		}
+
+		err = gt.WriteToGreentext(dest, defaultTemplate, lines, thumbnail, font, fontSize, previewOnly, bgColor, textColor, width, height, customDateTime)
 		if err != nil {
 			fmt.Println("Error generating greentext:", err)
 			return
@@ -161,4 +167,5 @@ func init() {
 	rootCmd.Flags().String("tmpl", "", "Path to a custom template file for the greentext")
 	rootCmd.Flags().Int("width", 0, "Width of the generated greentext image in pixels. Default is auto")
 	rootCmd.Flags().Int("height", 0, "Height of the generated greentext image in pixels. Default is auto")
+	rootCmd.Flags().StringP("datetime", "d", "", "Custom date/time for the greentext in format DD/MM/YYYY, HH:MM:SS or just DD/MM/YYYY (default: current time)")
 }

--- a/internal/gt/gt.go
+++ b/internal/gt/gt.go
@@ -3,9 +3,11 @@ package gt
 import (
 	"fmt"
 	"html/template"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	_ "embed"
@@ -23,11 +25,53 @@ type GTData struct {
 	Template      []byte
 }
 
-func WriteToGreentext(dest string, tmpl []byte, lines []string, thumbnailPath, font string, fontSize int, previewOnly bool, bgColor, textColor string, width, height int) error {
+func WriteToGreentext(dest string, tmpl []byte, lines []string, thumbnailPath, font string, fontSize int, previewOnly bool, bgColor, textColor string, width, height int, customDateTime string) error {
 
-	unixTime := time.Now().Unix()
-	timestamp := time.Unix(unixTime, 0).Format("02/01/2006, 15:04:05")
-	uniqueID := strconv.FormatInt(unixTime, 10)[:8] // For the part that says no.xxxxxxxx
+	var unixTime int64
+	var timestamp string
+
+	if customDateTime != "" {
+		// Check input is just a date (DD/MM/YYYY)
+		var parsedTime time.Time
+		var err error
+
+		if len(customDateTime) <= 10 && !strings.Contains(customDateTime, ":") {
+			// It's just a date, generate a random time
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			randomHour := r.Intn(24)   // 0-23 hours
+			randomMinute := r.Intn(60) // 0-59 minutes
+			randomSecond := r.Intn(60) // 0-59 seconds
+
+			// Format date with random time
+			fullDateTime := fmt.Sprintf("%s, %02d:%02d:%02d",
+				customDateTime,
+				randomHour,
+				randomMinute,
+				randomSecond)
+
+			parsedTime, err = time.Parse("02/01/2006, 15:04:05", fullDateTime)
+			if err != nil {
+				return fmt.Errorf("invalid date format: %v. Expected DD/MM/YYYY", err)
+			}
+
+			// Update timestamp to include random time
+			timestamp = fullDateTime
+		} else {
+			parsedTime, err = time.Parse("02/01/2006, 15:04:05", customDateTime)
+			if err != nil {
+				return fmt.Errorf("invalid datetime format: %v. Expected DD/MM/YYYY, HH:MM:SS", err)
+			}
+			timestamp = customDateTime
+		}
+
+		unixTime = parsedTime.Unix()
+	} else {
+		unixTime = time.Now().Unix()
+		timestamp = time.Unix(unixTime, 0).Format("02/01/2006, 15:04:05")
+	}
+
+	uniqueID := strconv.FormatInt(unixTime, 10)[:8]
+
 	styleBlock := template.HTML(fmt.Sprintf(`
     <style>
         body {


### PR DESCRIPTION
Add `-d`/`--datetime` flag allowing users to specify a custom timestamp for greentext.

- Support both full datetime (DD/MM/YYYY, HH:MM:SS) and date-only (DD/MM/YYYY) formats
- Generate random time values when only a date is provided

Example usage:
```bash
greentext -d "01/04/2023, 13:37:00" -o custom_full_datetime.png
greentext -d "25/12/2023" -o custom_date_only_and_random_time.png
```